### PR TITLE
feat: add redis-backed driver matching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+.PHONY: dev test lint sqlc migrate-up migrate-down
+
+GOFILES := $(shell find . -name '*.go' -not -path './vendor/*')
+
+mod:
+go mod tidy
+
+fmt:
+gofmt -w $(GOFILES)
+
+lint:
+golangci-lint run ./...
+
+sqlc:
+sqlc generate -f configs/sqlc.yaml
+
+migrate-up:
+golang-migrate -path migrations -database "${DATABASE_URL}" up
+
+migrate-down:
+golang-migrate -path migrations -database "${DATABASE_URL}" down 1
+
+test:
+go test ./...
+
+dev:
+docker compose up -d db redis nats
+air

--- a/README.md
+++ b/README.md
@@ -1,49 +1,71 @@
-# Task Management System
+# RideLite — میکروسرویس درخواست سفر، مچینگ و ETA
 
-This repository contains a simple task management web application built with **Node.js/Express** for the backend and **React** for the frontend.
+RideLite یک پروژهٔ مرجع برای نمایش مهارت‌های بک‌اند با Go است که جریان کامل یک سامانهٔ تاکسی‌آنلاین را با معماری میکروسرویسی شبیه‌سازی می‌کند. این پروژه برای مصاحبه‌ها و ارزیابی شرکت‌هایی مانند اسنپ طراحی شده است و بر مفاهیم حیاتی نظیر State Machine سفر، استریم لوکیشن رانندگان، محاسبهٔ ETA، Idempotency، Outbox، Observability و CI/CD تأکید دارد.
 
-## Features
-- User authentication with JWT
-- Password reset via email
-- Task CRUD operations
-- Role based access (admin, user)
-- Comment on tasks and tag users
-- Responsive frontend with React
+## نمای کلی معماری
 
-## Getting Started
+```
+┌────────┐        ┌────────────┐        ┌────────────┐
+│ Client │ ─────► │ API Gateway│ ─────► │ Trip Service│
+└────────┘        └────────────┘        └────────────┘
+                       │  ▲                     │
+                       │  │ gRPC                │ نردبان State Machine + Outbox
+                       ▼  │                     ▼
+                ┌──────────────┐        ┌──────────────┐
+                │ Location/ETA │◄──────►│ NATS Message │
+                │   Service    │        │     Bus      │
+                └──────────────┘        └──────────────┘
+                       │
+                       ▼
+                 PostgreSQL + Redis
+```
 
-### Backend
-1. Navigate to `server` and install dependencies:
-   ```bash
-   npm install
-   ```
-2. Copy `.env.example` to `.env` and update the values.
-3. Run the server:
-   ```bash
-   node server.js
-   ```
+- **API Gateway**: لایهٔ ورودی REST که احراز هویت JWT، Rate-Limit و مترک‌ها را مدیریت می‌کند.
+- **Trip Service**: مدیریت چرخهٔ عمر سفر، مچینگ راننده، ثبت رویدادها و انتشار Outbox.
+- **Location/ETA Service**: استریم موقعیت رانندگان با gRPC و محاسبهٔ ETA با استفاده از Redis و مدل‌های مسیریابی.
+- **NATS**: برای انتشار رویدادهای دامنه‌ای و آگاهی سرویس‌ها از تغییر وضعیت سفر.
+- **PostgreSQL + Redis**: ذخیرهٔ پایدار داده‌ها و کش موقعیت/حالت راننده.
 
-### Frontend
-1. Navigate to `client` and install dependencies:
-   ```bash
-   npm install
-   ```
-2. Start the React app:
-   ```bash
-   npm start
-   ```
+## سرویس‌ها و دایرکتوری‌ها
 
-## Deployment
+| مسیر | توضیح |
+|------|-------|
+| `cmd/apigateway` | راه‌اندازی API Gateway با chi و middlewares احراز هویت/آبزروبیلیتی |
+| `cmd/tripservice` | سرور HTTP برای مدیریت سفرها و webhook outbox worker |
+| `cmd/locationservice` | سرور gRPC استریم موقعیت و REST ETA |
+| `internal/trip` | لایه‌های handler/service/repository و منطق State Machine |
+| `internal/eta` | محاسبهٔ ETA، دسترسی به Redis و مدل‌های فاصله |
+| `internal/location` | مدیریت استریم gRPC و ذخیرهٔ لوکیشن |
+| `pkg/outbox` | پیاده‌سازی الگوی Outbox برای انتشار رویدادها |
+| `pkg/observability` | تنظیم zap، Prometheus و OpenTelemetry |
+| `configs` | فایل‌های پیکربندی sqlc، migrate و نمونه env |
+| `migrations` | اسکریپت‌های golang-migrate شامل اسکیمای اصلی |
 
-### Heroku (Backend)
-1. Create a Heroku app and add a MongoDB add-on or connection string.
-2. Set the environment variables from `.env` in Heroku settings.
-3. Push the contents of the `server` folder to Heroku or configure a multi-buildpack.
+## اجرای سریع در حالت توسعه
 
-### Netlify (Frontend)
-1. Create a new site from the `client` directory.
-2. Set the build command to `npm run build` and the publish directory to `build`.
-3. Ensure the API endpoint URLs in the frontend point to your Heroku backend.
+```bash
+make dev
+```
 
-## License
-MIT
+این دستور سرویس‌ها را در حالت توسعه با hot reload اجرا می‌کند (air) و دیتابیس/Redis/NATS را با Docker Compose بالا می‌آورد. برای اجرای کامل، پیش‌نیازهای زیر نیاز است:
+
+- Go 1.22+
+- Docker و Docker Compose
+- golang-migrate
+- sqlc
+
+## نکات برجسته
+
+- **Idempotency Key Middleware**: تضمین می‌کند درخواست‌های ایجاد سفر یا تغییر وضعیت در حالت تکراری به نتایج قبلی پاسخ دهند.
+- **State Machine Engine**: تغییر وضعیت‌ها با optimistic locking و ثبت رویداد در جدول `trip_events` انجام می‌شود.
+- **Outbox Dispatcher**: رویدادهای دامنه‌ای در جدول `outbox` ذخیره و توسط worker به NATS منتشر می‌شوند.
+- **Observability**: هر سرویس از zap برای لاگ ساختار‌یافته، Prometheus برای مترک‌ها و OpenTelemetry برای tracing استفاده می‌کند.
+- **تست‌ها**: نمونه تست‌های واحد برای لایهٔ سرویس با استفاده از in-memory repository قرار دارد.
+
+## مسیر توسعهٔ بعدی
+
+- پیاده‌سازی کامل الگوریتم مچینگ با Redis GeoIndex و پشتیبانی از backoff.
+- اتصال به موتور مسیریابی (OSRM/Valhalla) برای ETA دقیق.
+- اضافه کردن پوشش تست Integration با Testcontainers.
+- تکمیل داکیومنت Swagger و مثال‌های Postman.
+

--- a/cmd/apigateway/main.go
+++ b/cmd/apigateway/main.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	"go.uber.org/zap"
+
+	"github.com/example/ridellite/pkg/observability"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	logger := observability.SetupLogger("api-gateway")
+	defer logger.Sync() //nolint:errcheck
+
+	shutdown, err := observability.SetupTracer(ctx, "api-gateway")
+	if err != nil {
+		logger.Warn("tracer setup failed", zap.Error(err))
+	} else {
+		defer shutdown(context.Background())
+	}
+
+	tripURL := getenv("TRIP_SERVICE_URL", "http://localhost:8080")
+	etaURL := getenv("ETA_SERVICE_URL", "http://localhost:8081")
+
+	r := chi.NewRouter()
+	r.Use(middleware.RequestID, middleware.RealIP, middleware.Logger, middleware.Recoverer)
+	r.Mount("/observability", observability.MetricsRouter())
+	r.Mount("/v1/trips", http.StripPrefix("/v1/trips", http.HandlerFunc(proxy(tripURL+"/v1/trips"))))
+	r.Handle("/v1/eta", proxy(etaURL+"/v1/eta"))
+
+	srv := &http.Server{Addr: ":8088", Handler: r, ReadHeaderTimeout: 5 * time.Second}
+	go func() {
+		logger.Info("api gateway listening", zap.String("addr", srv.Addr))
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Fatal("http server", zap.Error(err))
+		}
+	}()
+
+	<-ctx.Done()
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = srv.Shutdown(shutdownCtx)
+}
+
+func proxy(target string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		req, err := http.NewRequestWithContext(r.Context(), r.Method, target+r.URL.Path, r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		req.Header = r.Header.Clone()
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+		copyHeader(w.Header(), resp.Header)
+		w.WriteHeader(resp.StatusCode)
+		_, _ = io.Copy(w, resp.Body)
+	}
+}
+
+func copyHeader(dst, src http.Header) {
+	for k, v := range src {
+		vv := make([]string, len(v))
+		copy(vv, v)
+		dst[k] = vv
+	}
+}
+
+func getenv(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/cmd/locationservice/main.go
+++ b/cmd/locationservice/main.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+
+	"github.com/example/ridellite/internal/eta/handler"
+	etasvc "github.com/example/ridellite/internal/eta/service"
+	"github.com/example/ridellite/internal/location"
+	"github.com/example/ridellite/pkg/observability"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	logger := observability.SetupLogger("location-service")
+	defer logger.Sync() //nolint:errcheck
+
+	shutdown, err := observability.SetupTracer(ctx, "location-service")
+	if err != nil {
+		logger.Warn("tracer setup failed", zap.Error(err))
+	} else {
+		defer shutdown(context.Background())
+	}
+
+	observer := location.NewStreamObserver()
+	etaSvc := etasvc.New(observer)
+
+	go runREST(logger, etaSvc)
+	go runGRPC(logger, observer)
+
+	<-ctx.Done()
+	logger.Info("shutdown signal received")
+}
+
+func runREST(logger *zap.Logger, etaSvc *etasvc.Service) {
+	r := chi.NewRouter()
+	r.Mount("/", handler.New(etaSvc).Router())
+	r.Mount("/observability", observability.MetricsRouter())
+
+	srv := &http.Server{Addr: ":8081", Handler: r, ReadHeaderTimeout: 5 * time.Second}
+	logger.Info("eta REST listening", zap.String("addr", srv.Addr))
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		logger.Fatal("eta rest server", zap.Error(err))
+	}
+}
+
+func runGRPC(logger *zap.Logger, observer *location.StreamObserver) {
+	lis, err := net.Listen("tcp", ":9090")
+	if err != nil {
+		logger.Fatal("listen grpc", zap.Error(err))
+	}
+
+	srv := grpc.NewServer()
+	RegisterLocationServer(srv, NewServer(observer))
+	logger.Info("location grpc listening", zap.String("addr", lis.Addr().String()))
+	if err := srv.Serve(lis); err != nil {
+		logger.Fatal("grpc serve", zap.Error(err))
+	}
+}

--- a/cmd/tripservice/main.go
+++ b/cmd/tripservice/main.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/nats-io/nats.go"
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+
+	"github.com/example/ridellite/internal/trip/domain"
+	"github.com/example/ridellite/internal/trip/handler"
+	"github.com/example/ridellite/internal/trip/matching"
+	"github.com/example/ridellite/internal/trip/repository"
+	tripservice "github.com/example/ridellite/internal/trip/service"
+	"github.com/example/ridellite/pkg/observability"
+	"github.com/example/ridellite/pkg/outbox"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	logger := observability.SetupLogger("trip-service")
+	defer logger.Sync() //nolint:errcheck
+
+	shutdown, err := observability.SetupTracer(ctx, "trip-service")
+	if err != nil {
+		logger.Warn("tracer setup failed", zap.Error(err))
+	} else {
+		defer shutdown(context.Background())
+	}
+
+	repo := repository.NewMemoryRepository()
+	idem := repository.NewMemoryIdempotencyRepo()
+	var matcher domain.MatchingEngine
+	var redisClient *redis.Client
+	if addr := os.Getenv("REDIS_ADDR"); addr != "" {
+		redisClient = redis.NewClient(&redis.Options{Addr: addr})
+		if err := redisClient.Ping(ctx).Err(); err != nil {
+			logger.Warn("redis ping failed", zap.Error(err))
+			_ = redisClient.Close()
+			redisClient = nil
+		} else {
+			defer redisClient.Close()
+			geo := matching.NewRedisGeoIndex(redisClient, "driver:locs")
+			reservation := matching.NewRedisReservationStore(redisClient)
+			cfg := matching.RedisMatcherConfig{}
+			if redisMatcher, err := matching.NewRedisMatcher(geo, reservation, cfg); err == nil {
+				matcher = redisMatcher
+			} else {
+				logger.Warn("redis matcher init failed", zap.Error(err))
+			}
+		}
+	}
+	if matcher == nil {
+		locationSource := matching.NewMemorySource()
+		reservation := matching.NewMemoryReservationStore()
+		matcher = matching.NewSimpleMatcher(locationSource, reservation, 5)
+	}
+
+	var natsConn *nats.Conn
+	if url := os.Getenv("NATS_URL"); url != "" {
+		if conn, err := nats.Connect(url); err == nil {
+			natsConn = conn
+			defer conn.Drain()
+		} else {
+			logger.Warn("nats connection failed", zap.Error(err))
+		}
+	}
+	publisher := outbox.NewPublisher(natsConn, "trip.events")
+
+	svc := tripservice.New(repo, publisher, matcher, domain.SystemClock{}, idem)
+	tripHTTP := handler.NewHTTP(svc)
+
+	r := chi.NewRouter()
+	r.Mount("/", tripHTTP.Router())
+	r.Mount("/observability", observability.MetricsRouter())
+
+	srv := &http.Server{
+		Addr:              ":8080",
+		Handler:           r,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		logger.Info("trip service listening", zap.String("addr", srv.Addr))
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Fatal("http server", zap.Error(err))
+		}
+	}()
+
+	<-ctx.Done()
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_ = srv.Shutdown(shutdownCtx)
+}

--- a/configs/app.example.env
+++ b/configs/app.example.env
@@ -1,0 +1,6 @@
+TRIP_SERVICE_URL=http://tripservice:8080
+ETA_SERVICE_URL=http://locationservice:8081
+NATS_URL=nats://nats:4222
+DATABASE_URL=postgres://postgres:postgres@db:5432/ridellite?sslmode=disable
+REDIS_ADDR=redis:6379
+JWT_SECRET=supersecret

--- a/configs/sqlc.yaml
+++ b/configs/sqlc.yaml
@@ -1,0 +1,11 @@
+version: "2"
+sql:
+  - engine: postgresql
+    queries: internal/db/queries
+    schema: migrations
+    gen:
+      go:
+        package: db
+        out: internal/db
+        emit_json_tags: true
+        emit_db_tags: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '3.8'
+services:
+  db:
+    image: postgis/postgis:15-3.3
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: ridelite
+    ports:
+      - "5432:5432"
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+  nats:
+    image: nats:2
+    command: ["-js"]
+    ports:
+      - "4222:4222"
+  tripservice:
+    build: .
+    command: ["go", "run", "./cmd/tripservice"]
+    environment:
+      NATS_URL: nats://nats:4222
+    depends_on:
+      - db
+      - redis
+      - nats
+  locationservice:
+    build: .
+    command: ["go", "run", "./cmd/locationservice"]
+    depends_on:
+      - redis
+      - nats
+  apigateway:
+    build: .
+    command: ["go", "run", "./cmd/apigateway"]
+    environment:
+      TRIP_SERVICE_URL: http://tripservice:8080
+      ETA_SERVICE_URL: http://locationservice:8081
+    depends_on:
+      - tripservice
+      - locationservice

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,40 @@
+module github.com/example/ridellite
+
+go 1.22
+
+require (
+    github.com/go-chi/chi/v5 v5.0.10
+    github.com/golang-jwt/jwt/v5 v5.2.1
+    github.com/google/uuid v1.5.0
+    github.com/redis/go-redis/v9 v9.2.1
+    github.com/nats-io/nats.go v1.32.0
+    github.com/prometheus/client_golang v1.18.0
+    github.com/stretchr/testify v1.8.4
+    go.opentelemetry.io/otel v1.24.0
+    go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.24.0
+    go.opentelemetry.io/otel/sdk v1.24.0
+    go.opentelemetry.io/otel/trace v1.24.0
+    go.uber.org/zap v1.26.0
+    google.golang.org/grpc v1.61.0
+)
+
+require (
+    github.com/beorn7/perks v1.0.1 // indirect
+    github.com/cespare/xxhash/v2 v2.2.0 // indirect
+    github.com/davecgh/go-spew v1.1.1 // indirect
+    github.com/gogo/protobuf v1.3.2 // indirect
+    github.com/golang/protobuf v1.5.3 // indirect
+    github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
+    github.com/pmezard/go-difflib v1.0.0 // indirect
+    github.com/prometheus/client_model v0.5.0 // indirect
+    github.com/prometheus/common v0.47.0 // indirect
+    github.com/prometheus/procfs v0.12.0 // indirect
+    go.uber.org/multierr v1.11.0 // indirect
+    go.uber.org/zap/exp v0.0.0-20221211195306-39dcb0f80fcb // indirect
+    golang.org/x/net v0.19.0 // indirect
+    golang.org/x/sys v0.15.0 // indirect
+    golang.org/x/text v0.14.0 // indirect
+    google.golang.org/genproto v0.0.0-20231106174013-bbf56f31fb17 // indirect
+    google.golang.org/protobuf v1.31.0 // indirect
+    github.com/alicebob/miniredis/v2 v2.30.4 // indirect
+)

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -1,0 +1,74 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// Claims extends standard registered claims with role information.
+type Claims struct {
+	Role string `json:"role"`
+	jwt.RegisteredClaims
+}
+
+// Middleware validates JWT tokens and injects claims into context.
+func Middleware(secret string, roles ...string) func(http.Handler) http.Handler {
+	allowed := make(map[string]struct{}, len(roles))
+	for _, r := range roles {
+		allowed[r] = struct{}{}
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tokenString := tokenFromHeader(r.Header.Get("Authorization"))
+			if tokenString == "" {
+				http.Error(w, "missing token", http.StatusUnauthorized)
+				return
+			}
+			claims := &Claims{}
+			token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (any, error) {
+				if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+					return nil, errors.New("unexpected signing method")
+				}
+				return []byte(secret), nil
+			})
+			if err != nil || !token.Valid {
+				http.Error(w, "invalid token", http.StatusUnauthorized)
+				return
+			}
+			if len(allowed) > 0 {
+				if _, ok := allowed[claims.Role]; !ok {
+					http.Error(w, "forbidden", http.StatusForbidden)
+					return
+				}
+			}
+			ctx := context.WithValue(r.Context(), claimsKey{}, claims)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// ClaimsFromContext retrieves claims from context.
+func ClaimsFromContext(ctx context.Context) (*Claims, bool) {
+	claims, ok := ctx.Value(claimsKey{}).(*Claims)
+	return claims, ok
+}
+
+type claimsKey struct{}
+
+func tokenFromHeader(header string) string {
+	if header == "" {
+		return ""
+	}
+	parts := strings.SplitN(header, " ", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	if !strings.EqualFold(parts[0], "Bearer") {
+		return ""
+	}
+	return parts[1]
+}

--- a/internal/db/queries/trips.sql
+++ b/internal/db/queries/trips.sql
@@ -1,0 +1,31 @@
+-- name: CreateTrip :one
+INSERT INTO trips (
+    id, rider_id, driver_id, pickup, dropoff, status,
+    requested_at, accepted_at, started_at, finished_at,
+    cancelled_at, price_cents, version
+) VALUES (
+    $1, $2, $3, ST_SetSRID(ST_Point($4, $5), 4326), ST_SetSRID(ST_Point($6, $7), 4326), $8,
+    $9, $10, $11, $12, $13, $14, $15
+)
+RETURNING *;
+
+-- name: GetTrip :one
+SELECT * FROM trips WHERE id = $1 LIMIT 1;
+
+-- name: UpdateTrip :one
+UPDATE trips
+SET
+    rider_id = $2,
+    driver_id = $3,
+    pickup = ST_SetSRID(ST_Point($4, $5), 4326),
+    dropoff = ST_SetSRID(ST_Point($6, $7), 4326),
+    status = $8,
+    requested_at = $9,
+    accepted_at = $10,
+    started_at = $11,
+    finished_at = $12,
+    cancelled_at = $13,
+    price_cents = $14,
+    version = version + 1
+WHERE id = $1
+RETURNING *;

--- a/internal/eta/handler/http.go
+++ b/internal/eta/handler/http.go
@@ -1,0 +1,56 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+
+	etasvc "github.com/example/ridellite/internal/eta/service"
+	"github.com/example/ridellite/internal/trip/domain"
+)
+
+// HTTP exposes the /v1/eta endpoint.
+type HTTP struct {
+	svc *etasvc.Service
+}
+
+// New creates the handler.
+func New(svc *etasvc.Service) *HTTP {
+	return &HTTP{svc: svc}
+}
+
+// Router builds the chi router.
+func (h *HTTP) Router() http.Handler {
+	r := chi.NewRouter()
+	r.Get("/v1/eta", h.estimate)
+	return r
+}
+
+func (h *HTTP) estimate(w http.ResponseWriter, r *http.Request) {
+	pickup := domain.GeoPoint{Lat: parseQueryFloat(r, "pickup_lat"), Lng: parseQueryFloat(r, "pickup_lng")}
+	dropoff := domain.GeoPoint{Lat: parseQueryFloat(r, "dropoff_lat"), Lng: parseQueryFloat(r, "dropoff_lng")}
+	driverETA, driverID := h.svc.EstimateDriverETA(r.Context(), pickup)
+	tripETA := h.svc.EstimateTripETA(r.Context(), pickup, dropoff)
+
+	resp := map[string]any{
+		"driver_eta_sec": driverETA.Seconds(),
+		"trip_eta_sec":   tripETA.Seconds(),
+	}
+	if driverID != nil {
+		resp["driver_id"] = driverID.String()
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func parseQueryFloat(r *http.Request, key string) float64 {
+	v, _ := strconv.ParseFloat(r.URL.Query().Get(key), 64)
+	return v
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/internal/eta/service/service.go
+++ b/internal/eta/service/service.go
@@ -1,0 +1,74 @@
+package service
+
+import (
+	"context"
+	"math"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/example/ridellite/internal/trip/domain"
+)
+
+// Repository exposes read methods for location snapshots.
+type Repository interface {
+	Snapshot(ctx context.Context, driverID uuid.UUID) (domain.LocationSnapshot, bool)
+	All() []domain.LocationSnapshot
+}
+
+// Service calculates ETAs using haversine distance and average speeds.
+type Service struct {
+	repo Repository
+}
+
+// New creates an ETA service.
+func New(repo Repository) *Service {
+	return &Service{repo: repo}
+}
+
+// EstimateDriverETA returns the fastest driver estimate from available snapshots.
+func (s *Service) EstimateDriverETA(ctx context.Context, pickup domain.GeoPoint) (time.Duration, *uuid.UUID) {
+	const avgSpeed = 30.0 // km/h
+	const meterPerSecond = avgSpeed * 1000.0 / 3600.0
+	snapshots := s.repo.All()
+	var bestDuration time.Duration
+	var bestDriver *uuid.UUID
+	for _, snap := range snapshots {
+		dist := haversine(snap.Point, pickup)
+		sec := dist / meterPerSecond
+		duration := time.Duration(sec) * time.Second
+		if bestDriver == nil || duration < bestDuration {
+			snapshotDriver := snap.DriverID
+			bestDriver = &snapshotDriver
+			bestDuration = duration
+		}
+	}
+	return bestDuration, bestDriver
+}
+
+// EstimateTripETA approximates total trip time using distance and average speed.
+func (s *Service) EstimateTripETA(_ context.Context, pickup, dropoff domain.GeoPoint) time.Duration {
+	const avgSpeed = 35.0 // km/h
+	const meterPerSecond = avgSpeed * 1000.0 / 3600.0
+	dist := haversine(pickup, dropoff)
+	sec := dist / meterPerSecond
+	return time.Duration(sec) * time.Second
+}
+
+func haversine(a, b domain.GeoPoint) float64 {
+	const earthRadius = 6371000.0
+	lat1 := toRadians(a.Lat)
+	lat2 := toRadians(b.Lat)
+	dlat := toRadians(b.Lat - a.Lat)
+	dlon := toRadians(b.Lng - a.Lng)
+
+	sinDlat := math.Sin(dlat / 2)
+	sinDlon := math.Sin(dlon / 2)
+	aa := sinDlat*sinDlat + math.Cos(lat1)*math.Cos(lat2)*sinDlon*sinDlon
+	c := 2 * math.Atan2(math.Sqrt(aa), math.Sqrt(1-aa))
+	return earthRadius * c
+}
+
+func toRadians(deg float64) float64 {
+	return deg * math.Pi / 180.0
+}

--- a/internal/location/pb.go
+++ b/internal/location/pb.go
@@ -1,0 +1,60 @@
+package location
+
+import "google.golang.org/grpc"
+
+// DriverLocation represents a streaming update.
+type DriverLocation struct {
+	DriverId string
+	Lat      float64
+	Lng      float64
+	Speed    float64
+	Accuracy float64
+	Ts       int64
+}
+
+// Ack is returned by the stream.
+type Ack struct{}
+
+// LocationServer defines the gRPC contract.
+type LocationServer interface {
+	StreamLocation(Location_StreamLocationServer) error
+}
+
+// RegisterLocationServer registers service implementation.
+func RegisterLocationServer(s *grpc.Server, srv LocationServer) {
+	s.RegisterService(&grpc.ServiceDesc{
+		ServiceName: "location.Location",
+		HandlerType: (*LocationServer)(nil),
+		Streams: []grpc.StreamDesc{{
+			StreamName:    "StreamLocation",
+			Handler:       _Location_StreamLocation_Handler,
+			ServerStreams: true,
+			ClientStreams: true,
+		}},
+	}, srv)
+}
+
+// Location_StreamLocationServer defines bidi stream interface.
+type Location_StreamLocationServer interface {
+	grpc.ServerStream
+	SendAndClose(*Ack) error
+	Recv() (*DriverLocation, error)
+}
+
+func _Location_StreamLocation_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(LocationServer).StreamLocation(&locationStreamServer{ServerStream: stream})
+}
+
+type locationStreamServer struct {
+	grpc.ServerStream
+}
+
+func (s *locationStreamServer) SendAndClose(*Ack) error { return nil }
+
+func (s *locationStreamServer) Recv() (*DriverLocation, error) {
+	msg := new(DriverLocation)
+	if err := s.ServerStream.RecvMsg(msg); err != nil {
+		return nil, err
+	}
+	return msg, nil
+}

--- a/internal/location/server.go
+++ b/internal/location/server.go
@@ -1,0 +1,37 @@
+package location
+
+import (
+	"io"
+
+	"github.com/google/uuid"
+
+	"github.com/example/ridellite/internal/trip/domain"
+)
+
+// Server implements the LocationServer interface.
+type Server struct {
+	observer *StreamObserver
+}
+
+// NewServer constructs a server.
+func NewServer(observer *StreamObserver) *Server {
+	return &Server{observer: observer}
+}
+
+// StreamLocation ingests driver locations and updates observer.
+func (s *Server) StreamLocation(stream Location_StreamLocationServer) error {
+	for {
+		msg, err := stream.Recv()
+		if err == io.EOF {
+			return stream.SendAndClose(&Ack{})
+		}
+		if err != nil {
+			return err
+		}
+		driverID, err := uuid.Parse(msg.DriverId)
+		if err != nil {
+			continue
+		}
+		s.observer.Update(stream.Context(), driverID, domain.GeoPoint{Lat: msg.Lat, Lng: msg.Lng}, msg.Speed, msg.Accuracy)
+	}
+}

--- a/internal/location/service.go
+++ b/internal/location/service.go
@@ -1,0 +1,54 @@
+package location
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/example/ridellite/internal/trip/domain"
+)
+
+// StreamObserver stores latest driver location snapshots.
+type StreamObserver struct {
+	mu        sync.RWMutex
+	snapshots map[uuid.UUID]domain.LocationSnapshot
+}
+
+// NewStreamObserver constructs the observer.
+func NewStreamObserver() *StreamObserver {
+	return &StreamObserver{snapshots: make(map[uuid.UUID]domain.LocationSnapshot)}
+}
+
+// Update stores snapshot data.
+func (o *StreamObserver) Update(_ context.Context, driverID uuid.UUID, point domain.GeoPoint, speed, accuracy float64) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.snapshots[driverID] = domain.LocationSnapshot{
+		DriverID: driverID,
+		Point:    point,
+		Speed:    speed,
+		Accuracy: accuracy,
+		Updated:  time.Now().UTC(),
+	}
+}
+
+// Snapshot returns the stored snapshot.
+func (o *StreamObserver) Snapshot(_ context.Context, driverID uuid.UUID) (domain.LocationSnapshot, bool) {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	snap, ok := o.snapshots[driverID]
+	return snap, ok
+}
+
+// All returns all snapshots.
+func (o *StreamObserver) All() []domain.LocationSnapshot {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	res := make([]domain.LocationSnapshot, 0, len(o.snapshots))
+	for _, snap := range o.snapshots {
+		res = append(res, snap)
+	}
+	return res
+}

--- a/internal/trip/domain/models.go
+++ b/internal/trip/domain/models.go
@@ -1,0 +1,117 @@
+package domain
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TripStatus represents the lifecycle states of a trip.
+type TripStatus string
+
+const (
+	StatusRequested       TripStatus = "REQUESTED"
+	StatusDriverAssigned  TripStatus = "DRIVER_ASSIGNED"
+	StatusDriverAccepted  TripStatus = "DRIVER_ACCEPTED"
+	StatusPickupEnRoute   TripStatus = "PICKUP_EN_ROUTE"
+	StatusInProgress      TripStatus = "IN_PROGRESS"
+	StatusCompleted       TripStatus = "COMPLETED"
+	StatusCancelledRider  TripStatus = "CANCELLED_BY_RIDER"
+	StatusCancelledDriver TripStatus = "CANCELLED_BY_DRIVER"
+)
+
+// ErrInvalidTransition is returned when a state transition is not allowed.
+var ErrInvalidTransition = errors.New("invalid trip state transition")
+
+// GeoPoint captures latitude and longitude using WGS84.
+type GeoPoint struct {
+	Lat float64 `json:"lat"`
+	Lng float64 `json:"lng"`
+}
+
+// Trip aggregates the data required to manage a ride lifecycle.
+type Trip struct {
+	ID          uuid.UUID
+	RiderID     uuid.UUID
+	DriverID    *uuid.UUID
+	Pickup      GeoPoint
+	Dropoff     GeoPoint
+	VehicleType string
+
+	Status      TripStatus
+	RequestedAt time.Time
+	AcceptedAt  *time.Time
+	StartedAt   *time.Time
+	FinishedAt  *time.Time
+	CancelledAt *time.Time
+	CancelledBy *TripStatus
+	PriceCents  int64
+	Version     int64
+}
+
+// TripEventType enumerates domain events published by the service.
+type TripEventType string
+
+const (
+	EventTripRequested  TripEventType = "TripRequested"
+	EventDriverAssigned TripEventType = "DriverAssigned"
+	EventDriverAccepted TripEventType = "DriverAccepted"
+	EventTripStarted    TripEventType = "TripStarted"
+	EventTripFinished   TripEventType = "TripFinished"
+	EventTripCancelled  TripEventType = "TripCancelled"
+)
+
+// TripEvent captures a domain event for the outbox pattern.
+type TripEvent struct {
+	ID        int64
+	TripID    uuid.UUID
+	Type      TripEventType
+	Payload   map[string]any
+	CreatedAt time.Time
+}
+
+// Repository describes persistence operations required by the service.
+type Repository interface {
+	CreateTrip(ctx context.Context, trip Trip) (Trip, error)
+	GetTripByID(ctx context.Context, id uuid.UUID) (Trip, error)
+	UpdateTrip(ctx context.Context, trip Trip) (Trip, error)
+	CreateTripEvent(ctx context.Context, event TripEvent) error
+}
+
+// IdempotencyRepository stores request/response pairs for idempotent APIs.
+type IdempotencyRepository interface {
+	GetResponse(ctx context.Context, key string) ([]byte, bool, error)
+	PutResponse(ctx context.Context, key string, payload []byte) error
+}
+
+// LocationSnapshot is cached to Redis for ETA/matching decisions.
+type LocationSnapshot struct {
+	DriverID uuid.UUID
+	Point    GeoPoint
+	Speed    float64
+	Accuracy float64
+	Updated  time.Time
+}
+
+// MatchingEngine selects a driver for a trip request.
+type MatchingEngine interface {
+	ReserveDriver(ctx context.Context, trip Trip) (*uuid.UUID, error)
+	ReleaseDriver(ctx context.Context, driverID uuid.UUID) error
+}
+
+// EventPublisher publishes domain events via the outbox worker.
+type EventPublisher interface {
+	Publish(ctx context.Context, event TripEvent) error
+}
+
+// Clock allows deterministic tests by mocking time.
+type Clock interface {
+	Now() time.Time
+}
+
+// SystemClock is the production implementation of Clock.
+type SystemClock struct{}
+
+func (SystemClock) Now() time.Time { return time.Now().UTC() }

--- a/internal/trip/handler/http.go
+++ b/internal/trip/handler/http.go
@@ -86,11 +86,11 @@ func (h *HTTP) cancelTrip(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid id", http.StatusBadRequest)
 		return
 	}
-	actor := domain.StatusCancelledRider
+	reason := domain.CancellationReasonRider
 	if r.URL.Query().Get("actor") == "driver" {
-		actor = domain.StatusCancelledDriver
+		reason = domain.CancellationReasonDriver
 	}
-	trip, err := h.svc.CancelTrip(r.Context(), id, actor)
+	trip, err := h.svc.CancelTrip(r.Context(), id, reason)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusConflict)
 		return

--- a/internal/trip/handler/http.go
+++ b/internal/trip/handler/http.go
@@ -1,0 +1,140 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/google/uuid"
+
+	"github.com/example/ridellite/internal/trip/domain"
+	"github.com/example/ridellite/internal/trip/service"
+)
+
+// HTTP exposes trip endpoints following the Clean Architecture flow.
+type HTTP struct {
+	svc *service.Service
+}
+
+// NewHTTP constructs a handler.
+func NewHTTP(svc *service.Service) *HTTP {
+	return &HTTP{svc: svc}
+}
+
+// Router builds the chi router with all endpoints and middlewares.
+func (h *HTTP) Router() http.Handler {
+	r := chi.NewRouter()
+	r.Use(middleware.RequestID, middleware.RealIP, middleware.Logger, middleware.Recoverer)
+	r.Post("/v1/trips", h.createTrip)
+	r.Get("/v1/trips/{id}", h.getTrip)
+	r.Post("/v1/trips/{id}/cancel", h.cancelTrip)
+	r.Post("/v1/trips/{id}/start", h.startTrip)
+	r.Post("/v1/trips/{id}/complete", h.completeTrip)
+	return r
+}
+
+type createTripRequest struct {
+	RiderID     string          `json:"rider_id"`
+	Pickup      domain.GeoPoint `json:"pickup"`
+	Dropoff     domain.GeoPoint `json:"dropoff"`
+	VehicleType string          `json:"vehicle_type"`
+}
+
+func (h *HTTP) createTrip(w http.ResponseWriter, r *http.Request) {
+	var payload createTripRequest
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	riderID, err := uuid.Parse(payload.RiderID)
+	if err != nil {
+		http.Error(w, "invalid rider_id", http.StatusBadRequest)
+		return
+	}
+
+	resp, err := h.svc.CreateTrip(r.Context(), r.Header.Get("Idempotency-Key"), service.CreateTripRequest{
+		RiderID:     riderID,
+		Pickup:      payload.Pickup,
+		Dropoff:     payload.Dropoff,
+		VehicleType: payload.VehicleType,
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusCreated, resp)
+}
+
+func (h *HTTP) getTrip(w http.ResponseWriter, r *http.Request) {
+	id, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		http.Error(w, "invalid id", http.StatusBadRequest)
+		return
+	}
+	trip, err := h.svc.GetTrip(r.Context(), id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	writeJSON(w, http.StatusOK, trip)
+}
+
+func (h *HTTP) cancelTrip(w http.ResponseWriter, r *http.Request) {
+	id, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		http.Error(w, "invalid id", http.StatusBadRequest)
+		return
+	}
+	actor := domain.StatusCancelledRider
+	if r.URL.Query().Get("actor") == "driver" {
+		actor = domain.StatusCancelledDriver
+	}
+	trip, err := h.svc.CancelTrip(r.Context(), id, actor)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusConflict)
+		return
+	}
+	writeJSON(w, http.StatusOK, trip)
+}
+
+func (h *HTTP) startTrip(w http.ResponseWriter, r *http.Request) {
+	id, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		http.Error(w, "invalid id", http.StatusBadRequest)
+		return
+	}
+	trip, err := h.svc.StartTrip(r.Context(), id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusConflict)
+		return
+	}
+	writeJSON(w, http.StatusOK, trip)
+}
+
+func (h *HTTP) completeTrip(w http.ResponseWriter, r *http.Request) {
+	id, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		http.Error(w, "invalid id", http.StatusBadRequest)
+		return
+	}
+	var payload struct {
+		PriceCents int64 `json:"price_cents"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	trip, err := h.svc.CompleteTrip(r.Context(), id, payload.PriceCents)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusConflict)
+		return
+	}
+	writeJSON(w, http.StatusOK, trip)
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/internal/trip/matching/geoindex.go
+++ b/internal/trip/matching/geoindex.go
@@ -1,0 +1,74 @@
+package matching
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/example/ridellite/internal/trip/domain"
+)
+
+// GeoIndex abstracts querying spatially indexed drivers.
+type GeoIndex interface {
+	Nearby(ctx context.Context, vehicleType string, point domain.GeoPoint, radiusKM float64, limit int) ([]uuid.UUID, error)
+}
+
+var errInvalidGeoResult = errors.New("invalid geo search result")
+
+// RedisGeoIndex implements GeoIndex using Redis GEO commands.
+type RedisGeoIndex struct {
+	client *redis.Client
+	key    string
+}
+
+// NewRedisGeoIndex constructs a Redis-backed geo index.
+func NewRedisGeoIndex(client *redis.Client, key string) *RedisGeoIndex {
+	if key == "" {
+		key = "driver:locs"
+	}
+	return &RedisGeoIndex{client: client, key: key}
+}
+
+// Nearby returns up to limit driver ids sorted by distance to the pickup point.
+func (r *RedisGeoIndex) Nearby(ctx context.Context, vehicleType string, point domain.GeoPoint, radiusKM float64, limit int) ([]uuid.UUID, error) {
+	if r == nil || r.client == nil {
+		return nil, errors.New("redis geo index not configured")
+	}
+
+	key := r.key
+	if vehicleType != "" {
+		key = fmt.Sprintf("%s:%s", key, vehicleType)
+	}
+
+	query := &redis.GeoSearchLocationQuery{
+		GeoSearchQuery: redis.GeoSearchQuery{
+			Key:        key,
+			Longitude:  point.Lng,
+			Latitude:   point.Lat,
+			Radius:     radiusKM,
+			RadiusUnit: "km",
+			Sort:       "ASC",
+			Count:      int64(limit),
+			WithDist:   true,
+		},
+	}
+
+	results, err := r.client.GeoSearchLocation(ctx, query).Result()
+	if err != nil {
+		return nil, fmt.Errorf("redis geosearch: %w", err)
+	}
+
+	ids := make([]uuid.UUID, 0, len(results))
+	for _, res := range results {
+		id, err := uuid.Parse(res.Name)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %s", errInvalidGeoResult, res.Name)
+		}
+		ids = append(ids, id)
+	}
+
+	return ids, nil
+}

--- a/internal/trip/matching/redis_matcher.go
+++ b/internal/trip/matching/redis_matcher.go
@@ -1,0 +1,92 @@
+package matching
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/example/ridellite/internal/trip/domain"
+)
+
+// RedisMatcherConfig configures the Redis backed matcher behaviour.
+type RedisMatcherConfig struct {
+	CandidateLimit int
+	SearchRadiusKM float64
+	MaxAttempts    int
+	Backoff        time.Duration
+	ReservationTTL time.Duration
+}
+
+// RedisMatcher implements domain.MatchingEngine using Redis data structures.
+type RedisMatcher struct {
+	geo          GeoIndex
+	reservations ReservationStore
+	cfg          RedisMatcherConfig
+}
+
+// NewRedisMatcher builds a matcher from redis-backed collaborators.
+func NewRedisMatcher(geo GeoIndex, reservations ReservationStore, cfg RedisMatcherConfig) (*RedisMatcher, error) {
+	if geo == nil {
+		return nil, errors.New("geo index is required")
+	}
+	if reservations == nil {
+		return nil, errors.New("reservation store is required")
+	}
+	if cfg.CandidateLimit <= 0 {
+		cfg.CandidateLimit = 5
+	}
+	if cfg.SearchRadiusKM <= 0 {
+		cfg.SearchRadiusKM = 5
+	}
+	if cfg.MaxAttempts <= 0 {
+		cfg.MaxAttempts = 3
+	}
+	if cfg.Backoff <= 0 {
+		cfg.Backoff = 100 * time.Millisecond
+	}
+	if cfg.ReservationTTL <= 0 {
+		cfg.ReservationTTL = 10 * time.Second
+	}
+	return &RedisMatcher{geo: geo, reservations: reservations, cfg: cfg}, nil
+}
+
+// ReserveDriver finds the closest reservable driver within the configured search radius.
+func (r *RedisMatcher) ReserveDriver(ctx context.Context, trip domain.Trip) (*uuid.UUID, error) {
+	var lastErr error
+	for attempt := 0; attempt < r.cfg.MaxAttempts; attempt++ {
+		candidates, err := r.geo.Nearby(ctx, trip.VehicleType, trip.Pickup, r.cfg.SearchRadiusKM, r.cfg.CandidateLimit)
+		if err != nil {
+			return nil, fmt.Errorf("geo nearby: %w", err)
+		}
+		for _, driverID := range candidates {
+			reserved, err := r.reservations.TryReserve(ctx, driverID, trip.ID, r.cfg.ReservationTTL)
+			if err != nil {
+				lastErr = err
+				continue
+			}
+			if reserved {
+				return &driverID, nil
+			}
+		}
+		if attempt < r.cfg.MaxAttempts-1 {
+			backoff := r.cfg.Backoff << attempt
+			select {
+			case <-time.After(backoff):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, ErrNoDriver
+}
+
+// ReleaseDriver releases the driver reservation.
+func (r *RedisMatcher) ReleaseDriver(ctx context.Context, driverID uuid.UUID) error {
+	return r.reservations.Release(ctx, driverID)
+}

--- a/internal/trip/matching/redis_matcher_test.go
+++ b/internal/trip/matching/redis_matcher_test.go
@@ -1,0 +1,85 @@
+package matching_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+
+	"github.com/example/ridellite/internal/trip/domain"
+	"github.com/example/ridellite/internal/trip/matching"
+)
+
+func TestRedisMatcherChoosesAvailableDriver(t *testing.T) {
+	client, cleanup := newRedisClient(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	geo := matching.NewRedisGeoIndex(client, "driver:locs")
+	store := matching.NewRedisReservationStore(client)
+	matcher, err := matching.NewRedisMatcher(geo, store, matching.RedisMatcherConfig{
+		CandidateLimit: 5,
+		SearchRadiusKM: 10,
+		MaxAttempts:    3,
+		Backoff:        10 * time.Millisecond,
+		ReservationTTL: time.Second,
+	})
+	require.NoError(t, err)
+
+	driver1 := uuid.New()
+	driver2 := uuid.New()
+	// driver1 closer
+	_, err = client.GeoAdd(ctx, "driver:locs:sedan", &redis.GeoLocation{Name: driver1.String(), Longitude: 51.4000, Latitude: 35.7000})
+	require.NoError(t, err)
+	_, err = client.GeoAdd(ctx, "driver:locs:sedan", &redis.GeoLocation{Name: driver2.String(), Longitude: 51.4050, Latitude: 35.7050})
+	require.NoError(t, err)
+
+	// reserve driver1 to simulate busy
+	reserved, err := store.TryReserve(ctx, driver1, uuid.New(), time.Second)
+	require.NoError(t, err)
+	require.True(t, reserved)
+
+	trip := domain.Trip{
+		ID:          uuid.New(),
+		Pickup:      domain.GeoPoint{Lat: 35.7001, Lng: 51.4001},
+		VehicleType: "sedan",
+	}
+
+	selected, err := matcher.ReserveDriver(ctx, trip)
+	require.NoError(t, err)
+	require.NotNil(t, selected)
+	require.Equal(t, driver2, *selected)
+}
+
+func TestRedisMatcherReleaseDriver(t *testing.T) {
+	client, cleanup := newRedisClient(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	geo := matching.NewRedisGeoIndex(client, "driver:locs")
+	store := matching.NewRedisReservationStore(client)
+	matcher, err := matching.NewRedisMatcher(geo, store, matching.RedisMatcherConfig{})
+	require.NoError(t, err)
+
+	driverID := uuid.New()
+	_, err = client.GeoAdd(ctx, "driver:locs:sedan", &redis.GeoLocation{Name: driverID.String(), Longitude: 0, Latitude: 0})
+	require.NoError(t, err)
+
+	trip := domain.Trip{ID: uuid.New(), Pickup: domain.GeoPoint{Lat: 0, Lng: 0}, VehicleType: "sedan"}
+	selected, err := matcher.ReserveDriver(ctx, trip)
+	require.NoError(t, err)
+	require.NotNil(t, selected)
+
+	key := "reserve:driver:" + driverID.String()
+	exists, err := client.Exists(ctx, key).Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), exists)
+
+	require.NoError(t, matcher.ReleaseDriver(ctx, driverID))
+	exists, err = client.Exists(ctx, key).Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(0), exists)
+}

--- a/internal/trip/matching/redis_store.go
+++ b/internal/trip/matching/redis_store.go
@@ -1,0 +1,47 @@
+package matching
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+)
+
+const reserveKeyPrefix = "reserve:driver:"
+
+// RedisReservationStore persists driver reservations with TTL.
+type RedisReservationStore struct {
+	client *redis.Client
+}
+
+// NewRedisReservationStore constructs a Redis backed reservation store.
+func NewRedisReservationStore(client *redis.Client) *RedisReservationStore {
+	return &RedisReservationStore{client: client}
+}
+
+// TryReserve attempts to lock the driver for the provided trip id.
+func (r *RedisReservationStore) TryReserve(ctx context.Context, driverID uuid.UUID, tripID uuid.UUID, ttl time.Duration) (bool, error) {
+	if r == nil || r.client == nil {
+		return false, fmt.Errorf("redis reservation store not configured")
+	}
+	key := reserveKeyPrefix + driverID.String()
+	ok, err := r.client.SetNX(ctx, key, tripID.String(), ttl).Result()
+	if err != nil {
+		return false, fmt.Errorf("redis setnx: %w", err)
+	}
+	return ok, nil
+}
+
+// Release removes the reservation lock.
+func (r *RedisReservationStore) Release(ctx context.Context, driverID uuid.UUID) error {
+	if r == nil || r.client == nil {
+		return nil
+	}
+	key := reserveKeyPrefix + driverID.String()
+	if err := r.client.Del(ctx, key).Err(); err != nil {
+		return fmt.Errorf("redis del: %w", err)
+	}
+	return nil
+}

--- a/internal/trip/matching/redis_store_test.go
+++ b/internal/trip/matching/redis_store_test.go
@@ -1,0 +1,69 @@
+package matching_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+
+	"github.com/example/ridellite/internal/trip/matching"
+)
+
+func newRedisClient(t *testing.T) (*redis.Client, func()) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	cleanup := func() {
+		_ = client.Close()
+		mr.Close()
+	}
+	return client, cleanup
+}
+
+func TestRedisReservationStoreReserveAndRelease(t *testing.T) {
+	client, cleanup := newRedisClient(t)
+	defer cleanup()
+
+	store := matching.NewRedisReservationStore(client)
+	ctx := context.Background()
+	driverID := uuid.New()
+	tripID := uuid.New()
+
+	reserved, err := store.TryReserve(ctx, driverID, tripID, time.Second)
+	require.NoError(t, err)
+	require.True(t, reserved)
+
+	reserved, err = store.TryReserve(ctx, driverID, uuid.New(), time.Second)
+	require.NoError(t, err)
+	require.False(t, reserved)
+
+	require.NoError(t, store.Release(ctx, driverID))
+
+	reserved, err = store.TryReserve(ctx, driverID, uuid.New(), time.Second)
+	require.NoError(t, err)
+	require.True(t, reserved)
+}
+
+func TestRedisReservationStoreTTLExpiry(t *testing.T) {
+	client, cleanup := newRedisClient(t)
+	defer cleanup()
+
+	store := matching.NewRedisReservationStore(client)
+	ctx := context.Background()
+	driverID := uuid.New()
+
+	reserved, err := store.TryReserve(ctx, driverID, uuid.New(), 100*time.Millisecond)
+	require.NoError(t, err)
+	require.True(t, reserved)
+
+	time.Sleep(120 * time.Millisecond)
+
+	reserved, err = store.TryReserve(ctx, driverID, uuid.New(), time.Second)
+	require.NoError(t, err)
+	require.True(t, reserved)
+}

--- a/internal/trip/matching/simple_matcher.go
+++ b/internal/trip/matching/simple_matcher.go
@@ -1,0 +1,134 @@
+package matching
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/example/ridellite/internal/trip/domain"
+)
+
+// ErrNoDriver indicates there is no driver available for reservation.
+var ErrNoDriver = errors.New("no driver available")
+
+// CandidateSource provides available drivers.
+type CandidateSource interface {
+	NearestDrivers(ctx context.Context, pickup domain.GeoPoint, vehicleType string, limit int) ([]uuid.UUID, error)
+}
+
+// ReservationStore ensures a driver is reserved exactly once.
+type ReservationStore interface {
+	TryReserve(ctx context.Context, driverID uuid.UUID, tripID uuid.UUID, ttl time.Duration) (bool, error)
+	Release(ctx context.Context, driverID uuid.UUID) error
+}
+
+// SimpleMatcher implements MatchingEngine using provided dependencies.
+type SimpleMatcher struct {
+	source CandidateSource
+	store  ReservationStore
+	limit  int
+	ttl    time.Duration
+}
+
+// NewSimpleMatcher constructs the matcher.
+func NewSimpleMatcher(source CandidateSource, store ReservationStore, limit int) *SimpleMatcher {
+	if limit <= 0 {
+		limit = 3
+	}
+	return &SimpleMatcher{source: source, store: store, limit: limit, ttl: 10 * time.Second}
+}
+
+// ReserveDriver selects the first reservable driver.
+func (m *SimpleMatcher) ReserveDriver(ctx context.Context, trip domain.Trip) (*uuid.UUID, error) {
+	candidates, err := m.source.NearestDrivers(ctx, trip.Pickup, trip.VehicleType, m.limit)
+	if err != nil {
+		return nil, err
+	}
+	for _, driverID := range candidates {
+		reserved, err := m.store.TryReserve(ctx, driverID, trip.ID, m.ttl)
+		if err != nil {
+			return nil, err
+		}
+		if reserved {
+			return &driverID, nil
+		}
+	}
+	return nil, ErrNoDriver
+}
+
+// ReleaseDriver frees any existing reservation for the driver.
+func (m *SimpleMatcher) ReleaseDriver(ctx context.Context, driverID uuid.UUID) error {
+	if m.store == nil {
+		return nil
+	}
+	return m.store.Release(ctx, driverID)
+}
+
+// MemorySource is a trivial in-memory candidate implementation.
+type MemorySource struct {
+	mu              sync.RWMutex
+	drivers         map[string]uuid.UUID
+	driverByVehicle map[uuid.UUID]string
+}
+
+// NewMemorySource constructs MemorySource.
+func NewMemorySource() *MemorySource {
+	return &MemorySource{drivers: make(map[string]uuid.UUID), driverByVehicle: make(map[uuid.UUID]string)}
+}
+
+// UpsertDriver stores driver coordinate hashed cell.
+func (m *MemorySource) UpsertDriver(_ context.Context, driverID uuid.UUID, vehicleType string, cell string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.drivers[cell] = driverID
+	m.driverByVehicle[driverID] = vehicleType
+}
+
+// NearestDrivers returns deterministic order for tests.
+func (m *MemorySource) NearestDrivers(_ context.Context, _ domain.GeoPoint, vehicleType string, limit int) ([]uuid.UUID, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var ids []uuid.UUID
+	for _, driverID := range m.drivers {
+		if vt, ok := m.driverByVehicle[driverID]; ok && vt == vehicleType {
+			ids = append(ids, driverID)
+		}
+	}
+	if len(ids) > limit {
+		ids = ids[:limit]
+	}
+	return ids, nil
+}
+
+// MemoryReservationStore ensures exclusive reservation.
+type MemoryReservationStore struct {
+	mu       sync.Mutex
+	reserved map[uuid.UUID]uuid.UUID
+}
+
+// NewMemoryReservationStore constructs MemoryReservationStore.
+func NewMemoryReservationStore() *MemoryReservationStore {
+	return &MemoryReservationStore{reserved: make(map[uuid.UUID]uuid.UUID)}
+}
+
+// TryReserve attempts to reserve a driver for trip.
+func (m *MemoryReservationStore) TryReserve(_ context.Context, driverID uuid.UUID, tripID uuid.UUID, _ time.Duration) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.reserved[driverID]; exists {
+		return false, nil
+	}
+	m.reserved[driverID] = tripID
+	return true, nil
+}
+
+// Release removes a driver reservation.
+func (m *MemoryReservationStore) Release(_ context.Context, driverID uuid.UUID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.reserved, driverID)
+	return nil
+}

--- a/internal/trip/repository/idempotency_memory.go
+++ b/internal/trip/repository/idempotency_memory.go
@@ -1,0 +1,33 @@
+package repository
+
+import (
+	"context"
+	"sync"
+)
+
+// MemoryIdempotencyRepo stores responses keyed by idempotency key.
+type MemoryIdempotencyRepo struct {
+	mu        sync.RWMutex
+	responses map[string][]byte
+}
+
+// NewMemoryIdempotencyRepo constructs repository.
+func NewMemoryIdempotencyRepo() *MemoryIdempotencyRepo {
+	return &MemoryIdempotencyRepo{responses: make(map[string][]byte)}
+}
+
+// GetResponse retrieves cached response.
+func (m *MemoryIdempotencyRepo) GetResponse(_ context.Context, key string) ([]byte, bool, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	value, ok := m.responses[key]
+	return append([]byte(nil), value...), ok, nil
+}
+
+// PutResponse stores response payload.
+func (m *MemoryIdempotencyRepo) PutResponse(_ context.Context, key string, payload []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.responses[key] = append([]byte(nil), payload...)
+	return nil
+}

--- a/internal/trip/repository/memory.go
+++ b/internal/trip/repository/memory.go
@@ -1,0 +1,73 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/google/uuid"
+
+	"github.com/example/ridellite/internal/trip/domain"
+)
+
+// ErrNotFound indicates missing entities.
+var ErrNotFound = errors.New("trip not found")
+
+// MemoryRepository provides an in-memory implementation suitable for tests and local demos.
+type MemoryRepository struct {
+	mu     sync.RWMutex
+	trips  map[uuid.UUID]domain.Trip
+	events []domain.TripEvent
+}
+
+// NewMemoryRepository constructs an empty memory repository.
+func NewMemoryRepository() *MemoryRepository {
+	return &MemoryRepository{trips: make(map[uuid.UUID]domain.Trip)}
+}
+
+// CreateTrip stores the trip and returns it.
+func (m *MemoryRepository) CreateTrip(_ context.Context, trip domain.Trip) (domain.Trip, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.trips[trip.ID] = trip
+	return trip, nil
+}
+
+// GetTripByID retrieves a trip.
+func (m *MemoryRepository) GetTripByID(_ context.Context, id uuid.UUID) (domain.Trip, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	trip, ok := m.trips[id]
+	if !ok {
+		return domain.Trip{}, ErrNotFound
+	}
+	return trip, nil
+}
+
+// UpdateTrip replaces the stored trip, performing optimistic locking on version.
+func (m *MemoryRepository) UpdateTrip(_ context.Context, trip domain.Trip) (domain.Trip, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	existing, ok := m.trips[trip.ID]
+	if !ok {
+		return domain.Trip{}, ErrNotFound
+	}
+	trip.Version = existing.Version + 1
+	m.trips[trip.ID] = trip
+	return trip, nil
+}
+
+// CreateTripEvent appends events to an in-memory buffer.
+func (m *MemoryRepository) CreateTripEvent(_ context.Context, event domain.TripEvent) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, event)
+	return nil
+}
+
+// Events returns stored events (for tests).
+func (m *MemoryRepository) Events() []domain.TripEvent {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return append([]domain.TripEvent(nil), m.events...)
+}

--- a/internal/trip/service/service.go
+++ b/internal/trip/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/example/ridellite/internal/trip/domain"
 )
 
-// Service coordinates trip operations between handlers and repositories.
 type Service struct {
 	repo       domain.Repository
 	events     domain.EventPublisher
@@ -19,12 +19,10 @@ type Service struct {
 	idempotent domain.IdempotencyRepository
 }
 
-// New constructs a Service with the required collaborators.
 func New(repo domain.Repository, events domain.EventPublisher, matcher domain.MatchingEngine, clock domain.Clock, idem domain.IdempotencyRepository) *Service {
 	return &Service{repo: repo, events: events, matcher: matcher, clock: clock, idempotent: idem}
 }
 
-// CreateTripRequest contains the request payload for creating a trip.
 type CreateTripRequest struct {
 	RiderID     uuid.UUID
 	Pickup      domain.GeoPoint
@@ -32,20 +30,21 @@ type CreateTripRequest struct {
 	VehicleType string
 }
 
-// CreateTripResponse returns the created trip identifier and status.
 type CreateTripResponse struct {
 	TripID uuid.UUID         `json:"trip_id"`
 	Status domain.TripStatus `json:"status"`
 }
 
-// CreateTrip handles a new trip creation request ensuring idempotency and driver matching.
 func (s *Service) CreateTrip(ctx context.Context, key string, req CreateTripRequest) (CreateTripResponse, error) {
 	if key != "" && s.idempotent != nil {
-		if cached, ok, err := s.idempotent.GetResponse(ctx, key); err == nil && ok {
+		if cached, ok, err := s.idempotent.GetResponse(ctx, key); err != nil {
+			return CreateTripResponse{}, fmt.Errorf("get idempotent response: %w", err)
+		} else if ok {
 			return decodeCreateTripResponse(cached)
 		}
 	}
 
+	now := s.clock.Now()
 	trip := domain.Trip{
 		ID:          uuid.New(),
 		RiderID:     req.RiderID,
@@ -53,7 +52,7 @@ func (s *Service) CreateTrip(ctx context.Context, key string, req CreateTripRequ
 		Dropoff:     req.Dropoff,
 		VehicleType: req.VehicleType,
 		Status:      domain.StatusRequested,
-		RequestedAt: s.clock.Now(),
+		RequestedAt: now,
 		Version:     1,
 	}
 
@@ -62,43 +61,47 @@ func (s *Service) CreateTrip(ctx context.Context, key string, req CreateTripRequ
 		return CreateTripResponse{}, fmt.Errorf("create trip: %w", err)
 	}
 
+	s.recordEvent(ctx, domain.TripEvent{ // TripRequested
+		TripID: created.ID,
+		Type:   domain.EventTripRequested,
+		Payload: map[string]any{
+			"rider_id": created.RiderID.String(),
+		},
+	})
+
 	if s.matcher != nil {
-		if driverID, err := s.matcher.ReserveDriver(ctx, created); err == nil && driverID != nil {
+		if driverID, matchErr := s.matcher.ReserveDriver(ctx, created); matchErr == nil && driverID != nil {
 			created.DriverID = driverID
 			created.Status = domain.StatusDriverAssigned
-			if _, err = s.repo.UpdateTrip(ctx, created); err != nil {
+			updated, updateErr := s.repo.UpdateTrip(ctx, created)
+			if updateErr != nil {
 				_ = s.matcher.ReleaseDriver(ctx, *driverID)
-				return CreateTripResponse{}, fmt.Errorf("assign driver: %w", err)
+				return CreateTripResponse{}, fmt.Errorf("assign driver: %w", updateErr)
 			}
-			_ = s.events.Publish(ctx, domain.TripEvent{
-				TripID:  created.ID,
-				Type:    domain.EventDriverAssigned,
-				Payload: map[string]any{"driver_id": driverID.String()},
+			created = updated
+			s.recordEvent(ctx, domain.TripEvent{
+				TripID: created.ID,
+				Type:   domain.EventDriverAssigned,
+				Payload: map[string]any{
+					"driver_id": driverID.String(),
+				},
 			})
 		}
 	}
 
-	event := domain.TripEvent{
-		TripID:  created.ID,
-		Type:    domain.EventTripRequested,
-		Payload: map[string]any{"rider_id": created.RiderID.String()},
-	}
-	_ = s.events.Publish(ctx, event)
-
 	resp := CreateTripResponse{TripID: created.ID, Status: created.Status}
 	if key != "" && s.idempotent != nil {
-		_ = s.idempotent.PutResponse(ctx, key, encodeCreateTripResponse(resp))
+		if err := s.idempotent.PutResponse(ctx, key, encodeCreateTripResponse(resp)); err != nil {
+			return CreateTripResponse{}, fmt.Errorf("store idempotent response: %w", err)
+		}
 	}
-
 	return resp, nil
 }
 
-// GetTrip retrieves a trip by identifier.
 func (s *Service) GetTrip(ctx context.Context, id uuid.UUID) (domain.Trip, error) {
 	return s.repo.GetTripByID(ctx, id)
 }
 
-// AcceptTrip allows a driver to accept an assigned trip.
 func (s *Service) AcceptTrip(ctx context.Context, tripID, driverID uuid.UUID) (domain.Trip, error) {
 	trip, err := s.repo.GetTripByID(ctx, tripID)
 	if err != nil {
@@ -106,58 +109,68 @@ func (s *Service) AcceptTrip(ctx context.Context, tripID, driverID uuid.UUID) (d
 	}
 
 	if trip.DriverID == nil || *trip.DriverID != driverID {
-		return domain.Trip{}, errors.New("driver not assigned to trip")
+		return domain.Trip{}, domain.ErrDriverMismatch
 	}
 
-	switch trip.Status {
-	case domain.StatusDriverAssigned:
-		now := s.clock.Now()
-		trip.Status = domain.StatusDriverAccepted
-		trip.AcceptedAt = &now
-	default:
+	if trip.Status == domain.StatusDriverAccepted {
+		return trip, nil
+	}
+
+	if !trip.Status.CanTransitionTo(domain.StatusDriverAccepted) {
 		return domain.Trip{}, domain.ErrInvalidTransition
 	}
+
+	now := s.clock.Now()
+	trip.Status = domain.StatusDriverAccepted
+	trip.AcceptedAt = &now
 
 	updated, err := s.repo.UpdateTrip(ctx, trip)
 	if err != nil {
 		return domain.Trip{}, err
 	}
 
-	_ = s.events.Publish(ctx, domain.TripEvent{
-		TripID:  updated.ID,
-		Type:    domain.EventDriverAccepted,
-		Payload: map[string]any{"driver_id": driverID.String()},
+	s.recordEvent(ctx, domain.TripEvent{
+		TripID: updated.ID,
+		Type:   domain.EventDriverAccepted,
+		Payload: map[string]any{
+			"driver_id": driverID.String(),
+		},
 	})
 
 	return updated, nil
 }
 
-// CancelTrip handles rider initiated cancellations prior to start.
-func (s *Service) CancelTrip(ctx context.Context, tripID uuid.UUID, actor domain.TripStatus) (domain.Trip, error) {
+func (s *Service) CancelTrip(ctx context.Context, tripID uuid.UUID, reason domain.CancellationReason) (domain.Trip, error) {
 	trip, err := s.repo.GetTripByID(ctx, tripID)
 	if err != nil {
 		return domain.Trip{}, err
 	}
 
-	switch trip.Status {
-	case domain.StatusRequested, domain.StatusDriverAssigned, domain.StatusDriverAccepted, domain.StatusPickupEnRoute:
-		now := s.clock.Now()
-		trip.Status = actor
-		trip.CancelledAt = &now
-		trip.CancelledBy = &actor
-	default:
+	newStatus := reason.CancellationStatus()
+	if trip.Status == newStatus {
+		return trip, nil
+	}
+
+	if !trip.Status.CanTransitionTo(newStatus) {
 		return domain.Trip{}, domain.ErrInvalidTransition
 	}
+
+	now := s.clock.Now()
+	trip.Status = newStatus
+	trip.CancelledAt = &now
+	trip.CancelledBy = &reason
 
 	updated, err := s.repo.UpdateTrip(ctx, trip)
 	if err != nil {
 		return domain.Trip{}, err
 	}
 
-	_ = s.events.Publish(ctx, domain.TripEvent{
-		TripID:  updated.ID,
-		Type:    domain.EventTripCancelled,
-		Payload: map[string]any{"status": string(actor)},
+	s.recordEvent(ctx, domain.TripEvent{
+		TripID: updated.ID,
+		Type:   domain.EventTripCancelled,
+		Payload: map[string]any{
+			"reason": string(reason),
+		},
 	})
 
 	if trip.DriverID != nil && s.matcher != nil {
@@ -167,14 +180,13 @@ func (s *Service) CancelTrip(ctx context.Context, tripID uuid.UUID, actor domain
 	return updated, nil
 }
 
-// StartTrip transitions to IN_PROGRESS when the driver begins the ride.
 func (s *Service) StartTrip(ctx context.Context, tripID uuid.UUID) (domain.Trip, error) {
 	trip, err := s.repo.GetTripByID(ctx, tripID)
 	if err != nil {
 		return domain.Trip{}, err
 	}
 
-	if trip.Status != domain.StatusPickupEnRoute && trip.Status != domain.StatusDriverAccepted {
+	if !trip.Status.CanTransitionTo(domain.StatusInProgress) {
 		return domain.Trip{}, domain.ErrInvalidTransition
 	}
 
@@ -187,22 +199,22 @@ func (s *Service) StartTrip(ctx context.Context, tripID uuid.UUID) (domain.Trip,
 		return domain.Trip{}, err
 	}
 
-	_ = s.events.Publish(ctx, domain.TripEvent{
-		TripID: updated.ID,
-		Type:   domain.EventTripStarted,
-	})
+	s.recordEvent(ctx, domain.TripEvent{TripID: updated.ID, Type: domain.EventTripStarted})
 
 	return updated, nil
 }
 
-// CompleteTrip marks the trip as completed.
 func (s *Service) CompleteTrip(ctx context.Context, tripID uuid.UUID, priceCents int64) (domain.Trip, error) {
 	trip, err := s.repo.GetTripByID(ctx, tripID)
 	if err != nil {
 		return domain.Trip{}, err
 	}
 
-	if trip.Status != domain.StatusInProgress {
+	if trip.Status == domain.StatusCompleted {
+		return trip, nil
+	}
+
+	if !trip.Status.CanTransitionTo(domain.StatusCompleted) {
 		return domain.Trip{}, domain.ErrInvalidTransition
 	}
 
@@ -216,10 +228,12 @@ func (s *Service) CompleteTrip(ctx context.Context, tripID uuid.UUID, priceCents
 		return domain.Trip{}, err
 	}
 
-	_ = s.events.Publish(ctx, domain.TripEvent{
-		TripID:  updated.ID,
-		Type:    domain.EventTripFinished,
-		Payload: map[string]any{"price_cents": priceCents},
+	s.recordEvent(ctx, domain.TripEvent{
+		TripID: updated.ID,
+		Type:   domain.EventTripFinished,
+		Payload: map[string]any{
+			"price_cents": priceCents,
+		},
 	})
 
 	if trip.DriverID != nil && s.matcher != nil {
@@ -230,32 +244,35 @@ func (s *Service) CompleteTrip(ctx context.Context, tripID uuid.UUID, priceCents
 }
 
 func encodeCreateTripResponse(resp CreateTripResponse) []byte {
-	return []byte(resp.TripID.String() + ":" + string(resp.Status))
+	payload, err := json.Marshal(resp)
+	if err != nil {
+		return nil
+	}
+	return payload
 }
 
 func decodeCreateTripResponse(b []byte) (CreateTripResponse, error) {
-	parts := string(b)
 	var resp CreateTripResponse
-	if len(parts) == 0 {
-		return resp, errors.New("empty payload")
+	if len(b) == 0 {
+		return resp, errors.New("empty idempotent payload")
 	}
-	// simple split without strings to avoid allocations.
-	var idStr string
-	var statusStr string
-	for i := range parts {
-		if parts[i] == ':' {
-			idStr = parts[:i]
-			if i+1 < len(parts) {
-				statusStr = parts[i+1:]
-			}
-			break
-		}
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return CreateTripResponse{}, err
 	}
-	id, err := uuid.Parse(idStr)
-	if err != nil {
-		return resp, err
+	if resp.TripID == uuid.Nil {
+		return CreateTripResponse{}, errors.New("missing trip id")
 	}
-	resp.TripID = id
-	resp.Status = domain.TripStatus(statusStr)
 	return resp, nil
+}
+
+func (s *Service) recordEvent(ctx context.Context, event domain.TripEvent) {
+	if event.CreatedAt.IsZero() {
+		event.CreatedAt = s.clock.Now()
+	}
+	if s.repo != nil {
+		_ = s.repo.CreateTripEvent(ctx, event)
+	}
+	if s.events != nil {
+		_ = s.events.Publish(ctx, event)
+	}
 }

--- a/internal/trip/service/service.go
+++ b/internal/trip/service/service.go
@@ -1,0 +1,261 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/example/ridellite/internal/trip/domain"
+)
+
+// Service coordinates trip operations between handlers and repositories.
+type Service struct {
+	repo       domain.Repository
+	events     domain.EventPublisher
+	matcher    domain.MatchingEngine
+	clock      domain.Clock
+	idempotent domain.IdempotencyRepository
+}
+
+// New constructs a Service with the required collaborators.
+func New(repo domain.Repository, events domain.EventPublisher, matcher domain.MatchingEngine, clock domain.Clock, idem domain.IdempotencyRepository) *Service {
+	return &Service{repo: repo, events: events, matcher: matcher, clock: clock, idempotent: idem}
+}
+
+// CreateTripRequest contains the request payload for creating a trip.
+type CreateTripRequest struct {
+	RiderID     uuid.UUID
+	Pickup      domain.GeoPoint
+	Dropoff     domain.GeoPoint
+	VehicleType string
+}
+
+// CreateTripResponse returns the created trip identifier and status.
+type CreateTripResponse struct {
+	TripID uuid.UUID         `json:"trip_id"`
+	Status domain.TripStatus `json:"status"`
+}
+
+// CreateTrip handles a new trip creation request ensuring idempotency and driver matching.
+func (s *Service) CreateTrip(ctx context.Context, key string, req CreateTripRequest) (CreateTripResponse, error) {
+	if key != "" && s.idempotent != nil {
+		if cached, ok, err := s.idempotent.GetResponse(ctx, key); err == nil && ok {
+			return decodeCreateTripResponse(cached)
+		}
+	}
+
+	trip := domain.Trip{
+		ID:          uuid.New(),
+		RiderID:     req.RiderID,
+		Pickup:      req.Pickup,
+		Dropoff:     req.Dropoff,
+		VehicleType: req.VehicleType,
+		Status:      domain.StatusRequested,
+		RequestedAt: s.clock.Now(),
+		Version:     1,
+	}
+
+	created, err := s.repo.CreateTrip(ctx, trip)
+	if err != nil {
+		return CreateTripResponse{}, fmt.Errorf("create trip: %w", err)
+	}
+
+	if s.matcher != nil {
+		if driverID, err := s.matcher.ReserveDriver(ctx, created); err == nil && driverID != nil {
+			created.DriverID = driverID
+			created.Status = domain.StatusDriverAssigned
+			if _, err = s.repo.UpdateTrip(ctx, created); err != nil {
+				_ = s.matcher.ReleaseDriver(ctx, *driverID)
+				return CreateTripResponse{}, fmt.Errorf("assign driver: %w", err)
+			}
+			_ = s.events.Publish(ctx, domain.TripEvent{
+				TripID:  created.ID,
+				Type:    domain.EventDriverAssigned,
+				Payload: map[string]any{"driver_id": driverID.String()},
+			})
+		}
+	}
+
+	event := domain.TripEvent{
+		TripID:  created.ID,
+		Type:    domain.EventTripRequested,
+		Payload: map[string]any{"rider_id": created.RiderID.String()},
+	}
+	_ = s.events.Publish(ctx, event)
+
+	resp := CreateTripResponse{TripID: created.ID, Status: created.Status}
+	if key != "" && s.idempotent != nil {
+		_ = s.idempotent.PutResponse(ctx, key, encodeCreateTripResponse(resp))
+	}
+
+	return resp, nil
+}
+
+// GetTrip retrieves a trip by identifier.
+func (s *Service) GetTrip(ctx context.Context, id uuid.UUID) (domain.Trip, error) {
+	return s.repo.GetTripByID(ctx, id)
+}
+
+// AcceptTrip allows a driver to accept an assigned trip.
+func (s *Service) AcceptTrip(ctx context.Context, tripID, driverID uuid.UUID) (domain.Trip, error) {
+	trip, err := s.repo.GetTripByID(ctx, tripID)
+	if err != nil {
+		return domain.Trip{}, err
+	}
+
+	if trip.DriverID == nil || *trip.DriverID != driverID {
+		return domain.Trip{}, errors.New("driver not assigned to trip")
+	}
+
+	switch trip.Status {
+	case domain.StatusDriverAssigned:
+		now := s.clock.Now()
+		trip.Status = domain.StatusDriverAccepted
+		trip.AcceptedAt = &now
+	default:
+		return domain.Trip{}, domain.ErrInvalidTransition
+	}
+
+	updated, err := s.repo.UpdateTrip(ctx, trip)
+	if err != nil {
+		return domain.Trip{}, err
+	}
+
+	_ = s.events.Publish(ctx, domain.TripEvent{
+		TripID:  updated.ID,
+		Type:    domain.EventDriverAccepted,
+		Payload: map[string]any{"driver_id": driverID.String()},
+	})
+
+	return updated, nil
+}
+
+// CancelTrip handles rider initiated cancellations prior to start.
+func (s *Service) CancelTrip(ctx context.Context, tripID uuid.UUID, actor domain.TripStatus) (domain.Trip, error) {
+	trip, err := s.repo.GetTripByID(ctx, tripID)
+	if err != nil {
+		return domain.Trip{}, err
+	}
+
+	switch trip.Status {
+	case domain.StatusRequested, domain.StatusDriverAssigned, domain.StatusDriverAccepted, domain.StatusPickupEnRoute:
+		now := s.clock.Now()
+		trip.Status = actor
+		trip.CancelledAt = &now
+		trip.CancelledBy = &actor
+	default:
+		return domain.Trip{}, domain.ErrInvalidTransition
+	}
+
+	updated, err := s.repo.UpdateTrip(ctx, trip)
+	if err != nil {
+		return domain.Trip{}, err
+	}
+
+	_ = s.events.Publish(ctx, domain.TripEvent{
+		TripID:  updated.ID,
+		Type:    domain.EventTripCancelled,
+		Payload: map[string]any{"status": string(actor)},
+	})
+
+	if trip.DriverID != nil && s.matcher != nil {
+		_ = s.matcher.ReleaseDriver(ctx, *trip.DriverID)
+	}
+
+	return updated, nil
+}
+
+// StartTrip transitions to IN_PROGRESS when the driver begins the ride.
+func (s *Service) StartTrip(ctx context.Context, tripID uuid.UUID) (domain.Trip, error) {
+	trip, err := s.repo.GetTripByID(ctx, tripID)
+	if err != nil {
+		return domain.Trip{}, err
+	}
+
+	if trip.Status != domain.StatusPickupEnRoute && trip.Status != domain.StatusDriverAccepted {
+		return domain.Trip{}, domain.ErrInvalidTransition
+	}
+
+	now := s.clock.Now()
+	trip.Status = domain.StatusInProgress
+	trip.StartedAt = &now
+
+	updated, err := s.repo.UpdateTrip(ctx, trip)
+	if err != nil {
+		return domain.Trip{}, err
+	}
+
+	_ = s.events.Publish(ctx, domain.TripEvent{
+		TripID: updated.ID,
+		Type:   domain.EventTripStarted,
+	})
+
+	return updated, nil
+}
+
+// CompleteTrip marks the trip as completed.
+func (s *Service) CompleteTrip(ctx context.Context, tripID uuid.UUID, priceCents int64) (domain.Trip, error) {
+	trip, err := s.repo.GetTripByID(ctx, tripID)
+	if err != nil {
+		return domain.Trip{}, err
+	}
+
+	if trip.Status != domain.StatusInProgress {
+		return domain.Trip{}, domain.ErrInvalidTransition
+	}
+
+	now := s.clock.Now()
+	trip.Status = domain.StatusCompleted
+	trip.FinishedAt = &now
+	trip.PriceCents = priceCents
+
+	updated, err := s.repo.UpdateTrip(ctx, trip)
+	if err != nil {
+		return domain.Trip{}, err
+	}
+
+	_ = s.events.Publish(ctx, domain.TripEvent{
+		TripID:  updated.ID,
+		Type:    domain.EventTripFinished,
+		Payload: map[string]any{"price_cents": priceCents},
+	})
+
+	if trip.DriverID != nil && s.matcher != nil {
+		_ = s.matcher.ReleaseDriver(ctx, *trip.DriverID)
+	}
+
+	return updated, nil
+}
+
+func encodeCreateTripResponse(resp CreateTripResponse) []byte {
+	return []byte(resp.TripID.String() + ":" + string(resp.Status))
+}
+
+func decodeCreateTripResponse(b []byte) (CreateTripResponse, error) {
+	parts := string(b)
+	var resp CreateTripResponse
+	if len(parts) == 0 {
+		return resp, errors.New("empty payload")
+	}
+	// simple split without strings to avoid allocations.
+	var idStr string
+	var statusStr string
+	for i := range parts {
+		if parts[i] == ':' {
+			idStr = parts[:i]
+			if i+1 < len(parts) {
+				statusStr = parts[i+1:]
+			}
+			break
+		}
+	}
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		return resp, err
+	}
+	resp.TripID = id
+	resp.Status = domain.TripStatus(statusStr)
+	return resp, nil
+}

--- a/internal/trip/service/service_test.go
+++ b/internal/trip/service/service_test.go
@@ -92,9 +92,11 @@ func TestCancelTripByRider(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	updated, err := svc.CancelTrip(context.Background(), trip.ID, domain.StatusCancelledRider)
+	updated, err := svc.CancelTrip(context.Background(), trip.ID, domain.CancellationReasonRider)
 	require.NoError(t, err)
 	require.Equal(t, domain.StatusCancelledRider, updated.Status)
+	require.NotNil(t, updated.CancelledBy)
+	require.Equal(t, domain.CancellationReasonRider, *updated.CancelledBy)
 	require.Len(t, matcher.releases, 1)
 	require.Equal(t, driverID, matcher.releases[0])
 }

--- a/internal/trip/service/service_test.go
+++ b/internal/trip/service/service_test.go
@@ -1,0 +1,131 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/example/ridellite/internal/trip/domain"
+	"github.com/example/ridellite/internal/trip/matching"
+	"github.com/example/ridellite/internal/trip/repository"
+	"github.com/example/ridellite/internal/trip/service"
+)
+
+type stubPublisher struct{ events []domain.TripEvent }
+
+type stubClock struct{ t time.Time }
+
+type stubMatcher struct {
+	id        *uuid.UUID
+	releases  []uuid.UUID
+	reserveFn func(domain.Trip) (*uuid.UUID, error)
+}
+
+func (s *stubPublisher) Publish(_ context.Context, event domain.TripEvent) error {
+	s.events = append(s.events, event)
+	return nil
+}
+
+func (s stubClock) Now() time.Time { return s.t }
+
+func (s *stubMatcher) ReserveDriver(_ context.Context, trip domain.Trip) (*uuid.UUID, error) {
+	if s.reserveFn != nil {
+		return s.reserveFn(trip)
+	}
+	return s.id, nil
+}
+
+func (s *stubMatcher) ReleaseDriver(_ context.Context, driverID uuid.UUID) error {
+	s.releases = append(s.releases, driverID)
+	return nil
+}
+
+func TestCreateTripAssignsDriverAndPublishesEvents(t *testing.T) {
+	repo := repository.NewMemoryRepository()
+	idem := repository.NewMemoryIdempotencyRepo()
+	driverID := uuid.New()
+	matcher := &stubMatcher{id: &driverID}
+	publisher := &stubPublisher{}
+	clock := stubClock{t: time.Unix(0, 0).UTC()}
+
+	svc := service.New(repo, publisher, matcher, clock, idem)
+	riderID := uuid.New()
+	resp, err := svc.CreateTrip(context.Background(), "key-1", service.CreateTripRequest{
+		RiderID:     riderID,
+		Pickup:      domain.GeoPoint{Lat: 35.7, Lng: 51.4},
+		Dropoff:     domain.GeoPoint{Lat: 35.75, Lng: 51.5},
+		VehicleType: "sedan",
+	})
+	require.NoError(t, err)
+	require.Equal(t, domain.StatusDriverAssigned, resp.Status)
+
+	// idempotent re-call returns cached response
+	cached, err := svc.CreateTrip(context.Background(), "key-1", service.CreateTripRequest{RiderID: riderID})
+	require.NoError(t, err)
+	require.Equal(t, resp.TripID, cached.TripID)
+
+	require.Len(t, publisher.events, 2)
+	require.Equal(t, domain.EventDriverAssigned, publisher.events[0].Type)
+	require.Equal(t, domain.EventTripRequested, publisher.events[1].Type)
+}
+
+func TestCancelTripByRider(t *testing.T) {
+	repo := repository.NewMemoryRepository()
+	publisher := &stubPublisher{}
+	clock := stubClock{t: time.Unix(0, 0).UTC()}
+	matcher := &stubMatcher{}
+	svc := service.New(repo, publisher, matcher, clock, repository.NewMemoryIdempotencyRepo())
+	riderID := uuid.New()
+	driverID := uuid.New()
+	trip, err := repo.CreateTrip(context.Background(), domain.Trip{
+		ID:          uuid.New(),
+		RiderID:     riderID,
+		Pickup:      domain.GeoPoint{Lat: 35.7, Lng: 51.4},
+		Dropoff:     domain.GeoPoint{Lat: 35.75, Lng: 51.5},
+		VehicleType: "sedan",
+		Status:      domain.StatusDriverAssigned,
+		RequestedAt: clock.Now(),
+		DriverID:    &driverID,
+	})
+	require.NoError(t, err)
+
+	updated, err := svc.CancelTrip(context.Background(), trip.ID, domain.StatusCancelledRider)
+	require.NoError(t, err)
+	require.Equal(t, domain.StatusCancelledRider, updated.Status)
+	require.Len(t, matcher.releases, 1)
+	require.Equal(t, driverID, matcher.releases[0])
+}
+
+func TestCompleteTripReleasesDriver(t *testing.T) {
+	repo := repository.NewMemoryRepository()
+	publisher := &stubPublisher{}
+	clock := stubClock{t: time.Unix(0, 0).UTC()}
+	matcher := &stubMatcher{}
+	driverID := uuid.New()
+	trip, err := repo.CreateTrip(context.Background(), domain.Trip{
+		ID:          uuid.New(),
+		RiderID:     uuid.New(),
+		Pickup:      domain.GeoPoint{Lat: 0, Lng: 0},
+		Dropoff:     domain.GeoPoint{Lat: 1, Lng: 1},
+		VehicleType: "sedan",
+		Status:      domain.StatusInProgress,
+		RequestedAt: clock.Now(),
+		DriverID:    &driverID,
+	})
+	require.NoError(t, err)
+
+	svc := service.New(repo, publisher, matcher, clock, repository.NewMemoryIdempotencyRepo())
+	_, err = svc.CompleteTrip(context.Background(), trip.ID, 1234)
+	require.NoError(t, err)
+	require.Len(t, matcher.releases, 1)
+	require.Equal(t, driverID, matcher.releases[0])
+}
+
+func TestMatcherNoDriver(t *testing.T) {
+	matcher := matching.NewSimpleMatcher(matching.NewMemorySource(), matching.NewMemoryReservationStore(), 3)
+	_, err := matcher.ReserveDriver(context.Background(), domain.Trip{Pickup: domain.GeoPoint{}, VehicleType: "sedan"})
+	require.Error(t, err)
+}

--- a/migrations/000001_init.sql
+++ b/migrations/000001_init.sql
@@ -1,0 +1,63 @@
+-- +migrate Up
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+CREATE TABLE users (
+    id UUID PRIMARY KEY,
+    role TEXT CHECK (role IN ('rider','driver','admin')) NOT NULL,
+    phone TEXT UNIQUE,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE drivers (
+    id UUID PRIMARY KEY REFERENCES users(id),
+    vehicle_type TEXT,
+    status TEXT,
+    updated_at TIMESTAMPTZ
+);
+
+CREATE TABLE trips (
+    id UUID PRIMARY KEY,
+    rider_id UUID REFERENCES users(id),
+    driver_id UUID REFERENCES users(id),
+    pickup GEOMETRY(POINT, 4326),
+    dropoff GEOMETRY(POINT, 4326),
+    status TEXT,
+    requested_at TIMESTAMPTZ,
+    accepted_at TIMESTAMPTZ,
+    started_at TIMESTAMPTZ,
+    finished_at TIMESTAMPTZ,
+    cancelled_at TIMESTAMPTZ,
+    price_cents INT,
+    version INT DEFAULT 1
+);
+
+CREATE TABLE trip_events (
+    id BIGSERIAL PRIMARY KEY,
+    trip_id UUID REFERENCES trips(id),
+    event_type TEXT,
+    payload JSONB,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE idempotency_keys (
+    key TEXT PRIMARY KEY,
+    request_hash TEXT,
+    response JSONB,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE outbox (
+    id BIGSERIAL PRIMARY KEY,
+    topic TEXT,
+    payload JSONB,
+    published BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- +migrate Down
+DROP TABLE IF EXISTS outbox;
+DROP TABLE IF EXISTS idempotency_keys;
+DROP TABLE IF EXISTS trip_events;
+DROP TABLE IF EXISTS trips;
+DROP TABLE IF EXISTS drivers;
+DROP TABLE IF EXISTS users;

--- a/pkg/observability/setup.go
+++ b/pkg/observability/setup.go
@@ -1,0 +1,55 @@
+package observability
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	"go.opentelemetry.io/otel/sdk/resource"
+	"go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.uber.org/zap"
+)
+
+// SetupLogger returns a production zap logger or falls back to a no-op logger.
+func SetupLogger(service string) *zap.Logger {
+	logger, err := zap.NewProduction()
+	if err != nil {
+		return zap.NewNop()
+	}
+	return logger.With(zap.String("service", service))
+}
+
+// SetupTracer configures an OTEL tracer provider with stdout exporter.
+func SetupTracer(ctx context.Context, service string) (func(context.Context) error, error) {
+	exporter, err := stdouttrace.New(stdouttrace.WithPrettyPrint())
+	if err != nil {
+		return nil, fmt.Errorf("create exporter: %w", err)
+	}
+	tp := trace.NewTracerProvider(
+		trace.WithBatcher(exporter),
+		trace.WithResource(resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceName(service),
+		)),
+	)
+	otel.SetTracerProvider(tp)
+	return tp.Shutdown, nil
+}
+
+// MetricsRouter exposes Prometheus metrics and health endpoints.
+func MetricsRouter() http.Handler {
+	r := chi.NewRouter()
+	r.Use(middleware.Recoverer)
+	r.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	r.Handle("/metrics", promhttp.Handler())
+	return r
+}

--- a/pkg/outbox/publisher.go
+++ b/pkg/outbox/publisher.go
@@ -1,0 +1,79 @@
+package outbox
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/example/ridellite/internal/trip/domain"
+)
+
+// Publisher writes trip events to a NATS subject.
+type Publisher struct {
+	conn    *nats.Conn
+	subject string
+}
+
+// NewPublisher builds a Publisher using the provided NATS connection.
+func NewPublisher(conn *nats.Conn, subject string) *Publisher {
+	return &Publisher{conn: conn, subject: subject}
+}
+
+// Publish satisfies domain.EventPublisher.
+func (p *Publisher) Publish(ctx context.Context, event domain.TripEvent) error {
+	if p == nil || p.conn == nil {
+		return nil
+	}
+
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("marshal event: %w", err)
+	}
+
+	return p.conn.PublishMsg(&nats.Msg{Subject: p.subject, Data: payload, Header: map[string][]string{
+		"x-trace-id":   {traceIDFromContext(ctx)},
+		"x-event-type": {string(event.Type)},
+	}})
+}
+
+func traceIDFromContext(ctx context.Context) string {
+	span := trace.SpanFromContext(ctx)
+	if span == nil {
+		return ""
+	}
+	sc := span.SpanContext()
+	if !sc.IsValid() {
+		return ""
+	}
+	return sc.TraceID().String()
+}
+
+// Worker pulls events from the database outbox and publishes them to NATS.
+type Worker struct {
+	Loader    func(ctx context.Context) ([]domain.TripEvent, error)
+	Marker    func(ctx context.Context, events []domain.TripEvent) error
+	Publisher domain.EventPublisher
+}
+
+// Run executes the worker loop once.
+func (w *Worker) Run(ctx context.Context) error {
+	events, err := w.Loader(ctx)
+	if err != nil {
+		return fmt.Errorf("load events: %w", err)
+	}
+	if len(events) == 0 {
+		return nil
+	}
+	for _, evt := range events {
+		if err := w.Publisher.Publish(ctx, evt); err != nil {
+			return err
+		}
+	}
+	if err := w.Marker(ctx, events); err != nil {
+		return fmt.Errorf("mark published: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add redis geo index and reservation store to back the matching engine with TTL reservations and redis fallback
- wire the trip service to use the redis matcher when available and release driver holds on cancellation/completion
- exercise the new matcher and reservation behaviour with unit tests, including service release coverage

## Testing
- `go test ./...` *(fails: missing go.sum entries because modules cannot be downloaded in this offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_690996cea6188328ad24ea35080e088d